### PR TITLE
Add AudioNode hooks to support additional AudioContext cases

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -31,16 +31,11 @@ function APV3_UN1QU3_debugMessage(...args) {
 }
 
 async function APV3_UN1QU3_maybeSetSinkId(targetElement, trigger, sinkId) {
-	if (sinkId === "default") {
-		sinkId = "";
-	}
-	if (sinkId === targetElement.sinkId) {
-		return true;
-	}
 	try {
+		// Get delegate for sink ID management
 		let sinkIdReceiver;
 		if (targetElement instanceof AudioContext) {
-			// Web Audio API: Direct AudioContext events (e.g., resume)
+			// Web Audio API: Direct AudioContext events (e.g., "resume")
 			sinkIdReceiver = targetElement;
 		} else if (targetElement instanceof AudioNode) {
 			// Web Audio API: Handle AudioNode updates by assigning the AudioContext sink directly
@@ -49,6 +44,14 @@ async function APV3_UN1QU3_maybeSetSinkId(targetElement, trigger, sinkId) {
 			// Other receivers (HTML media elements)
 			sinkIdReceiver = targetElement;
 		}
+		// Get intended new sink ID
+		if (sinkId === "default") {
+			sinkId = "";
+		}
+		if (sinkId === sinkIdReceiver.sinkId) {
+			return true;
+		}
+		// Set new sink ID
 		APV3_UN1QU3_debugMessage("| " + trigger + "(try):", targetElement.constructor.name, "| targetElement:", targetElement,
 			"| foundViaMethod:", targetElement.foundViaMethod,
 			"| oldSinkId:", sinkIdReceiver.sinkId, "| sinkId:", sinkId);

--- a/extension/main.js
+++ b/extension/main.js
@@ -37,22 +37,26 @@ async function APV3_UN1QU3_maybeSetSinkId(targetElement, trigger, sinkId) {
 	if (sinkId === targetElement.sinkId) {
 		return true;
 	}
-	if ((targetElement instanceof HTMLMediaElement) && (targetElement.sourceOfAudioContext)) {
-		// Skip setsinkId() on HTMLMediaElement(s)s that were used to
-		// create MediaElementAudioSourceNode(s) of an AudioContext.
-		APV3_UN1QU3_debugMessage("| " + trigger + "(skip):", targetElement.constructor.name, "| targetElement:", targetElement,
-				"| sourceOfAudioContext:", targetElement.sourceOfAudioContext, "| foundViaMethod:", targetElement.foundViaMethod);
-		return false;
-	}
 	try {
+		let sinkIdReceiver;
+		if (targetElement instanceof AudioContext) {
+			// Web Audio API: Direct AudioContext events (e.g., resume)
+			sinkIdReceiver = targetElement;
+		} else if (targetElement instanceof AudioNode) {
+			// Web Audio API: Handle AudioNode updates by assigning the AudioContext sink directly
+			sinkIdReceiver = targetElement.context;
+		} else {
+			// Other receivers (HTML media elements)
+			sinkIdReceiver = targetElement;
+		}
 		APV3_UN1QU3_debugMessage("| " + trigger + "(try):", targetElement.constructor.name, "| targetElement:", targetElement,
-			"| sourceOfAudioContext:", targetElement.sourceOfAudioContext, "| foundViaMethod:", targetElement.foundViaMethod,
-			"| oldSinkId:", targetElement.sinkId, "| sinkId:", sinkId);
-		await targetElement.setSinkId(sinkId);
+			"| foundViaMethod:", targetElement.foundViaMethod,
+			"| oldSinkId:", sinkIdReceiver.sinkId, "| sinkId:", sinkId);
+		await sinkIdReceiver.setSinkId(sinkId);
 		return true;
 	} catch(error) {
 		APV3_UN1QU3_debugMessage("| " + trigger + "(catch):", targetElement.constructor.name, "| targetElement:", targetElement,
-			"| sourceOfAudioContext:", targetElement.sourceOfAudioContext, "| foundViaMethod:", targetElement.foundViaMethod,
+			"| foundViaMethod:", targetElement.foundViaMethod,
 			"| oldSinkId:", targetElement.sinkId, "| sinkId:", sinkId, "| error:", error);
 		return false;
 	}
@@ -140,52 +144,38 @@ function APV3_UN1QU3_hookHTMLMediaElement_various() {
 	};
 }
 
-// Hook all AudioContext.prototype create functions to catch any AudioContexts.
+// Hook all Web Audio API (AudioContext) related prototype functions to manage AudioContext sinks.
 function APV3_UN1QU3_hookAudioContext_create() {
-	// Alias AudioContext.prototype to allow for shorter line length.
+	// Handle direct AudioContext interactions (cover additional cases, such as on-resume if
+	// extension is not loaded until after AudioContext is created)
 	const AC = AudioContext.prototype;
 	// Don't double-hook if we already did in this context.
-	if (typeof(AC.createMediaElementSource_noHook) !== "function") {
+	if (typeof(AC.resume_noHook) !== "function") {
 		// Save the original functions for callback.
-		AC.createMediaElementSource_noHook = AC.createMediaElementSource;
-		AC.createMediaStreamSource_noHook = AC.createMediaStreamSource;
-		AC.createMediaStreamDestination_noHook = AC.createMediaStreamDestination;
-		AC.createMediaStreamTrackSource_noHook = AC.createMediaStreamTrackSource;
+		AC.resume_noHook = AC.resume;
 	}
 	// Set our hooks
 	// Each hooked function simply calls addListenerAndSetSinkId on the object
 	// before calling and returning the value from the original function.
-	AC.createMediaElementSource = function(...args) {
-		APV3_UN1QU3_addListenerAndSetSinkId(this, "createMediaElementSource_hook");
-		// Mark the HTMLMediaElement (args[0]) used to create the MediaElementAudioSourceNode
-		// as being used by an AudioContext to prevent calling setSinkId() on it.
-		args[0].sourceOfAudioContext = true;
-		return this.createMediaElementSource_noHook.apply(this, args);
-	};
-	AC.createMediaStreamSource = function(...args) {
-		APV3_UN1QU3_addListenerAndSetSinkId(this, "createMediaStreamSource_hook");
-		return this.createMediaStreamSource_noHook.apply(this, args);
-	};
-	AC.createMediaStreamDestination = function(...args) {
-		APV3_UN1QU3_addListenerAndSetSinkId(this, "createMediaStreamDestination_hook");
-		return this.createMediaStreamDestination_noHook.apply(this, args);
-	};
-	AC.createMediaStreamTrackSource = function(...args) {
-		APV3_UN1QU3_addListenerAndSetSinkId(this, "createMediaStreamTrackSource_hook");
-		return this.createMediaStreamTrackSource_noHook.apply(this, args);
-	};
+	AC.resume = function(...args) {
+		APV3_UN1QU3_addListenerAndSetSinkId(this, "resume_hook");
+		return this.resume_noHook.apply(this, args);
+	}
 
-	// Handle various AudioNode-based types, such as AudioBufferSourceNode, ConstantSourceNode,
-	// MediaElementSourceNode, etc. These follow a newer, MDN-recommended IoC pattern where
-	// AudioContext is no longer natively aware of all possible implementations, but rather
-	// AudioNode subtypes are responsible for referencing the AudioContext during construction.
+	// Handle AudioContext via its various AudioNode-based types, such as AudioBufferSourceNode,
+	// ConstantSourceNode, MediaElementSourceNode, etc. These follow the MDN-recommended IoC pattern
+	// for the Web Audio API, creating notes via AudioNode subtype constructors rather than
+	// AudioContext factory methods. For reference, see MDN:
+	// https://developer.mozilla.org/en-US/docs/Web/API/AudioNode#creating_an_audionode
 	const AN = AudioNode.prototype;
+	// Don't double-hook if we already did in this context.
 	if (typeof(AN.connect_noHook) !== "function") {
+		// Save the original functions for callback.
 		AN.connect_noHook = AN.connect;
 	}
 	// Set our hooks
-	// This follows the same pattern as above. Listeners are added such that sink IDs can be
-	// assigned during calls.
+	// Each hooked function simply calls addListenerAndSetSinkId on the object
+	// before calling and returning the value from the original function.
 	AN.connect = function(...args) {
 		APV3_UN1QU3_addListenerAndSetSinkId(this, "connect_hook");
 		return this.connect_noHook.apply(this, args);

--- a/extension/main.js
+++ b/extension/main.js
@@ -151,6 +151,7 @@ function APV3_UN1QU3_hookAudioContext_create() {
 		AC.createMediaStreamSource_noHook = AC.createMediaStreamSource;
 		AC.createMediaStreamDestination_noHook = AC.createMediaStreamDestination;
 		AC.createMediaStreamTrackSource_noHook = AC.createMediaStreamTrackSource;
+		AC.createBufferSource_noHook = AC.createBufferSource;
 	}
 	// Set our hooks
 	// Each hooked function simply calls addListenerAndSetSinkId on the object
@@ -173,6 +174,10 @@ function APV3_UN1QU3_hookAudioContext_create() {
 	AC.createMediaStreamTrackSource = function(...args) {
 		APV3_UN1QU3_addListenerAndSetSinkId(this, "createMediaStreamTrackSource_hook");
 		return this.createMediaStreamTrackSource_noHook.apply(this, args);
+	};
+	AC.createBufferSource = function(...args) {
+		APV3_UN1QU3_addListenerAndSetSinkId(this, "createBufferSource_hook");
+		return this.createBufferSource_noHook.apply(this, args);
 	};
 }
 

--- a/extension/main.js
+++ b/extension/main.js
@@ -31,6 +31,9 @@ function APV3_UN1QU3_debugMessage(...args) {
 }
 
 async function APV3_UN1QU3_maybeSetSinkId(targetElement, trigger, sinkId) {
+	if (sinkId === "default") {
+		sinkId = "";
+	}
 	try {
 		// Get delegate for sink ID management
 		let sinkIdReceiver;
@@ -44,10 +47,7 @@ async function APV3_UN1QU3_maybeSetSinkId(targetElement, trigger, sinkId) {
 			// Other receivers (HTML media elements)
 			sinkIdReceiver = targetElement;
 		}
-		// Get intended new sink ID
-		if (sinkId === "default") {
-			sinkId = "";
-		}
+		// Avoid redundant assignments
 		if (sinkId === sinkIdReceiver.sinkId) {
 			return true;
 		}

--- a/extension/main.js
+++ b/extension/main.js
@@ -151,7 +151,6 @@ function APV3_UN1QU3_hookAudioContext_create() {
 		AC.createMediaStreamSource_noHook = AC.createMediaStreamSource;
 		AC.createMediaStreamDestination_noHook = AC.createMediaStreamDestination;
 		AC.createMediaStreamTrackSource_noHook = AC.createMediaStreamTrackSource;
-		AC.createBufferSource_noHook = AC.createBufferSource;
 	}
 	// Set our hooks
 	// Each hooked function simply calls addListenerAndSetSinkId on the object
@@ -175,10 +174,22 @@ function APV3_UN1QU3_hookAudioContext_create() {
 		APV3_UN1QU3_addListenerAndSetSinkId(this, "createMediaStreamTrackSource_hook");
 		return this.createMediaStreamTrackSource_noHook.apply(this, args);
 	};
-	AC.createBufferSource = function(...args) {
-		APV3_UN1QU3_addListenerAndSetSinkId(this, "createBufferSource_hook");
-		return this.createBufferSource_noHook.apply(this, args);
-	};
+
+	// Handle various AudioNode-based types, such as AudioBufferSourceNode, ConstantSourceNode,
+	// MediaElementSourceNode, etc. These follow a newer, MDN-recommended IoC pattern where
+	// AudioContext is no longer natively aware of all possible implementations, but rather
+	// AudioNode subtypes are responsible for referencing the AudioContext during construction.
+	const AN = AudioNode.prototype;
+	if (typeof(AN.connect_noHook) !== "function") {
+		AN.connect_noHook = AN.connect;
+	}
+	// Set our hooks
+	// This follows the same pattern as above. Listeners are added such that sink IDs can be
+	// assigned during calls.
+	AN.connect = function(...args) {
+		APV3_UN1QU3_addListenerAndSetSinkId(this, "connect_hook");
+		return this.connect_noHook.apply(this, args);
+	}
 }
 
 // Hook Element.prototype.attachShadow so we see any shadowRoots created.


### PR DESCRIPTION
This PR replaces the `AudioContext` factory-based hooks with `AudioNode#connect` hooks. This supports additional cases, including constructor-based `AudioNode` creation (rather than factory-based) and after-page-load extension functionality through `AudioContext#resume`.

Factory methods are not deprecated, but their constructor alternatives are recommended. Per commentary in MDN (https://developer.mozilla.org/en-US/docs/Web/API/AudioNode#creating_an_audionode):

> You are free to use either constructors or factory methods, or mix both, however there are advantages to using the constructors:
> 
> - All parameters can be set during construction time and don't need to be set individually.
> - You can [sub-class an audio node](https://github.com/WebAudio/web-audio-api/issues/251). While the actual processing is done internally by the browser and cannot be altered, you could write a wrapper around an audio node to provide custom properties and methods.
> - Slightly better performance: In both Chrome and Firefox, the factory methods call the constructors internally.
>
> Brief history: The first version of the Web Audio spec only defined the factory methods. After a [design review in October 2013](https://github.com/WebAudio/web-audio-api/issues/250), it was decided to add constructors because they have numerous benefits over factory methods. The constructors were added to the spec from August to October 2016. Factory methods continue to be included in the spec and are not deprecated.

The original PR intent was to support `BaseAudioContext.createBufferSource` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createBufferSource)), such as on [myNoise.net](https://mynoise.net/NoiseMachines/whiteNoiseGenerator.php). However, diving in after seeing MDN's constructor recommendation, it seems that `AudioNode#connect` to connect to an `AudioContext#destination` is a *hard requirement* of the Web Audio API (reference: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API), and thus this change should hopefully cover all remaining `AudioContext` cases not supported by the current implementation.

Tested sites so far appear to all be working as expected:
- app.pluralsight.com
- deezer.com
- music.youtube.com
- mynoise.net (fixed by this PR)
- pandora.com
- soundcloud.com
- spotify.com
- www.youtube.com

I'm not aware of other `AudioContext` cases in the wild, but would love to validate on more if we have other samples.